### PR TITLE
Fix repository links for i.MX ATF and OP-TEE

### DIFF
--- a/support/overlay/arm-trusted-firmware/default.nix
+++ b/support/overlay/arm-trusted-firmware/default.nix
@@ -122,7 +122,7 @@ in {
 
   armTrustedFirmwareIMX8QM = buildArmTrustedFirmware rec {
     src = fetchGit {
-      url = "https://source.codeaurora.org/external/imx/imx-atf";
+      url = "https://github.com/nxp-imx/imx-atf.git";
       ref = "lf_v2.6";
     };
     platform = "imx8qm";

--- a/support/overlay/imx-firmware/imx8qm/imx-optee-os.nix
+++ b/support/overlay/imx-firmware/imx8qm/imx-optee-os.nix
@@ -26,7 +26,7 @@ pkgs.stdenv.mkDerivation rec {
   ];
 
   src = fetchGit {
-    url = "https://source.codeaurora.org/external/imx/imx-optee-os.git";
+    url = "https://github.com/nxp-imx/imx-optee-os.git";
     ref = "lf-5.15.32_2.0.0";
   };
 


### PR DESCRIPTION
Previously, Nix took existing copies of that repos from it's local /nix/store, thus, I missed these two links in my recent commits.